### PR TITLE
chore: remove env variable dependency for local DB setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ git clone <repo-url>
 
 pip install -r requirements.txt
 ```
-Add `DATABASE_URL = sqlite:///local.db` in your environment variables.
-
 Go to project root folder and execute `python3 main.py`.
 
 Go to `https://localhost:5000/ to see the site

--- a/config.py
+++ b/config.py
@@ -1,4 +1,7 @@
 import os
+
+basedir = os.path.abspath(os.path.dirname(__file__))
+
 class DevelopmentConfig:
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL')
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or 'sqlite:///' + os.path.join(basedir, 'local.db')


### PR DESCRIPTION
if DATABASE_URL env variable is not defined, SQLALCHEMY_DATABASE_URI points to local.db file which is present in project root folder